### PR TITLE
Allow For More EPD Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # PiArtFrame
 
-To run the script, first wire up the Raspberry Pi with a waveshare 7.5inch panel.
-Then you need to install the waveshare Python library from https://www.waveshare.com/wiki/7.5inch_e-Paper_HAT_Manual#Working_With_Raspberry_Pi and place the waveshare_epd folder (found at found at e-Paper/RaspberryPi_JetsonNano/python/lib/waveshare_epd) inside this folder. If someone has a more seamless way of installing the eink driver I'd be keen to update it.
+To run the script, first wire up the Raspberry Pi with an e-Ink panel.
 
-After installing the waveshare library, this should be sufficient to set up the rest of your environment:
-```
-pip install pillow numpy tqdm
-```
+Install the needed Python requirements with:
 
-When you're ready to run, check that DEBUG is set to False inside main.py, otherwise the script will try to show the render via Pillow, not via the eink panel.
+```
+pip install -r requirements.txt
+```
+When you're ready to run, check the following:
+
+1. Set the `DISPLAY_TYPE` variable to the type of e-ink panel you have. [Click here](https://github.com/robweber/omni-epd#displays-implemented) for a list of supported devices.
+2. Set the `DEBUG` flag to False inside main.py, otherwise the script will try to show the render via Pillow, not via the e-ink panel.
 
 Then simply run python3 main.py and you should get going!
 

--- a/main.py
+++ b/main.py
@@ -1,21 +1,32 @@
 from mandelbrot import Mandelbrot
 from PIL import Image as im
 import numpy as np
+import sys
+
+# Set to the name of your e-ink device (https://github.com/robweber/omni-epd#displays-implemented)
+DISPLAY_TYPE = "waveshare_epd.epd7in5_V2"
 
 # Disable when running the waveshare panel
 DEBUG = False
 
 if not DEBUG:
-    from waveshare_epd import epd7in5_V2
+    from omni_epd import displayfactory, EPDNotFoundError
 
 mandelbrot = Mandelbrot()
 
 if not DEBUG:
-    epd = epd7in5_V2.EPD()
-    epd.init()
-    epd.Clear()
+    try:
+        epd = displayfactory.load_display_driver(DISPLAY_TYPE)
+    except EPDNotFoundError:
+        print(f"Couldn't find {DISPLAY_TYPE}")
+        sys.exit()
+
+    epd.prepare()
+    epd.clear()
     epd.sleep()
 
+print(epd.width)
+print(epd.height)
 while True:
     print("Starting render...")
     mandelbrot.render(800,480)
@@ -29,9 +40,9 @@ while True:
     if DEBUG:
         image.show()
     else:
-        epd.init()
-        epd.Clear()
-        epd.display(epd.getbuffer(image))
+        epd.prepare()
+        epd.clear()
+        epd.display(image)
         epd.sleep()
 
     mandelbrot.zoom_on_interesting_area()

--- a/main.py
+++ b/main.py
@@ -14,6 +14,9 @@ if not DEBUG:
 
 mandelbrot = Mandelbrot()
 
+# default height and width - need to hardcode for debug mode
+WIDTH = 800
+HEIGHT = 480
 if not DEBUG:
     try:
         epd = displayfactory.load_display_driver(DISPLAY_TYPE)
@@ -21,15 +24,16 @@ if not DEBUG:
         print(f"Couldn't find {DISPLAY_TYPE}")
         sys.exit()
 
+    WIDTH = epd.width
+    HEIGHT = epd.height
+
     epd.prepare()
     epd.clear()
     epd.sleep()
 
-print(epd.width)
-print(epd.height)
 while True:
     print("Starting render...")
-    mandelbrot.render(800,480)
+    mandelbrot.render(WIDTH,HEIGHT)
     print("Done!")
     arr = mandelbrot.get_render()
     arr = (np.asarray(arr)*255).astype(np.uint8)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pillow
+numpy
+tqdm
+git+https://github.com/robweber/omni-epd.git#egg=omni-epd


### PR DESCRIPTION
I took a run at replacing the hardcoded `epd7in5_V2` with the [omni-epd](https://github.com/robweber/omni-epd) display library. This will allow for a wider variety of displays to be used without having to update the codebase much. It's almost a 1:1 drop-in replacement but below I'll highlight the main changes. I tried to change as little existing code as needed to get this working. 

Python libraries moved to `requirements.txt` so they can all be installed quickly. New omni-epd lib requirement will pull in the needed Waveshare and other e-ink drivers. 

Inside the `main.py` file the following changes:

1. Display driver to load is now in a variable called `DISPLAY_TYPE`. Supported types can be found [here](https://github.com/robweber/omni-epd#displays-implemented). 
2. `init()` method call was changed to `prepare()` as that is the omni-epd equivalent. 
3. `Clear()` is now `clear()`, again for consistency. This is uniform across all omni-epd display types. 
4. No need to call `epd.getbuffer()` as omni-epd does this for you. 
5. Finally the width and height of the e-ink display are now pulled from the driver instead of being hardcoded for the image generation to accomodate different sized panels. 